### PR TITLE
Add metric names

### DIFF
--- a/src/definition/node.go
+++ b/src/definition/node.go
@@ -38,40 +38,45 @@ type LtmNodeStatsEntryValueNestedStats struct {
 	Kind    string `json:"kind"`
 	Entries struct {
 		AvailabilityState struct {
-			Description string
+      ProcessedDescription *int `metric_name:"node.availabilityState" source_type:"gauge"`
+      Description string
 		} `json:"status.availabilityState"`
 		CurrentConnections struct {
-			Value int
+      Value int `metric_name:"node.connections" source_type:"gauge"`
 		} `json:"serverside.curConns"`
 		CurrentSessions struct {
-			Value int
+      Value int `metric_name:"node.sessions" source_type:"gauge"`
 		} `json:"curSessions"`
 		DataIn struct {
-			Value int
+      ProcessedValue int `metric_name:"node.inDataInBytes" source_type:"rate"`
+      Value int
 		} `json:"serverside.bitsIn"`
 		DataOut struct {
-			Value int
+      ProcessedValue int `metric_name:"node.outDataInBytes" source_type:"rate"`
+      Value int
 		} `json:"serverside.bitsOut"`
 		EnabledState struct {
-			Description string
+      ProcessedDescription *int `metric_name:"node.enabled" source_type:"gauge"`
+      Description string
 		} `json:"status.enabledState"`
 		MonitorStatus struct {
-			Description string
+      ProcessedDescription *int `metric_name:"node.monitorStatus" source_type:"gauge"`
+      Description string
 		} `json:"monitorStatus"`
 		PacketsIn struct {
-			Value int
+      Value int `metric_name:"node.packetsReceived" source_type:"rate"`
 		} `json:"serverside.pktsIn"`
 		PacketsOut struct {
-			Value int
+      Value int `metric_name:"node.packetsSent" source_type:"rate"`
 		} `json:"serverside.pktsOut"`
 		Requests struct {
-			Value int
+      Value int `metric_name:"node.requests" source_type:"rate"`
 		} `json:"totRequests"`
 		SessionStatus struct {
-			Description string
+      ProcessedDescription *int `metric_name:"node.sessionStatus" source_type:"gauge"`
 		} `json:"sessionStatus"`
 		StatusReason struct {
-			Description string
+      Description string `metric_name:"node.statusReason" source_type:"attribute"`
 		} `json:"status.statusReason"`
 	}
 }

--- a/src/definition/pool.go
+++ b/src/definition/pool.go
@@ -29,40 +29,45 @@ type LtmPoolStatsEntryValueNestedStats struct {
 	Kind    string `json:"kind"`
 	Entries struct {
 		ActiveMemberCount struct {
-			Value int
+      Value int `metric_name:"pool.activeMembers" source_type:"gauge"`
 		} `json:"activeMemberCnt"`
 		AvailabilityState struct {
-			Description string
+      ProcessedDescription *int `metric_name:"pool.availabilityState" source_type:"gauge"`
+      Description string
 		} `json:"status.availabilityState"`
 		CurrentConnections struct {
-			Value int
+      Value int `metric_name:"pool.connections" source_type:"gauge"`
 		} `json:"serverside.curConns"`
 		DataIn struct {
-			Value int
+      ProcessedValue *int `metric_name:"pool.inDataInBytes" source_type:"rate"`
+      Value int
 		} `json:"serverside.bitsIn"`
 		DataOut struct {
-			Value int
+      ProcessedValue *int  `metric_name:"pool.outDataInBytes" source_type:"rate"`
+      Value int
 		} `json:"serverside.bitsOut"`
 		EnabledState struct {
-			Description string
+      ProcessedDescription *int `metric_name:"pool.enabled" source_type:"rate"`
+      Description string
 		} `json:"status.enabledState"`
 		PacketsIn struct {
-			Value int
+      Value int `metric_name:"pool.packetsReceived" source_type:"rate"`
 		} `json:"serverside.pktsIn"`
 		PacketsOut struct {
-			Value int
+      Value int `metric_name:"pool.packetsSent" source_type:"rate"`
 		} `json:"serverside.pktsOut"`
 		Requests struct {
-			Value int
+      Value int `metric_name:"pool.requests" source_type:"rate"`
 		} `json:"totRequests"`
 		StatusReason struct {
-			Description string
+      Description string `metric_name:"pool.statusReason" source_type:"gauge"`
 		} `json:"status.statusReason"`
 		MonitorRule struct {
-			Description string
+      Description string 
 		} `json:"monitorRule"`
 		MaxConnections struct {
-			Value int
+      Value int
 		} `json:"serverside.maxConns"`
 	}
 }
+

--- a/src/definition/pool_member.go
+++ b/src/definition/pool_member.go
@@ -26,40 +26,45 @@ type LtmPoolMemberStatsEntryValueNestedStats struct {
 	Kind    string `json:"kind"`
 	Entries struct {
 		AvailabilityState struct {
-			Description string
+      ProcessedDescription *int `metric_name:"member.availabilityState" source_type:"gauge"`
+      Description string
 		} `json:"status.availabilityState"`
 		CurrentConnections struct {
-			Value int
+      Value int `metric_name:"member.connections" source_type:"gauge"`
 		} `json:"serverside.curConns"`
 		CurrentSessions struct {
-			Value int
+      Value int `metric_name:"member.sessions" source_type:"gauge"`
 		} `json:"curSessions"`
 		DataIn struct {
-			Value int
+      ProcessedValue *int `metric_name:"member.inDataInBytes" source_type:"rate"`
+      Value int
 		} `json:"serverside.bitsIn"`
 		DataOut struct {
-			Value int
+      ProcessedValue *int `metric_name:"member.outDataInBytes" source_type:"rate"`
 		} `json:"serverside.bitsOut"`
 		EnabledState struct {
-			Description string
+      ProcessedDescription *int `metric_name:"member.enabled" source_type:"gauge"`
+      Description string
 		} `json:"status.enabledState"`
 		MonitorStatus struct {
-			Description string
+      ProcessedDescription *string `metric_name:"member.monitorStatus" source_type:"gauge"`
+      Description string
 		} `json:"monitorStatus"`
 		PacketsIn struct {
-			Value int
+      Value int `metric_name:"member.packetsReceived" source_type:"rate"`
 		} `json:"serverside.pktsIn"`
 		PacketsOut struct {
-			Value int
+      Value int `metric_name:"member.packetsSent" source_type:"rate"`
 		} `json:"serverside.pktsOut"`
 		Requests struct {
-			Value int
+      Value int `metric_name:"member.requests" source_type:"rate"`
 		} `json:"totRequests"`
 		SessionStatus struct {
-			Description string
+      ProcessedDescription *int `metric_name:"member.sessionStatus" source_type:"gauge"`
+      Description string
 		} `json:"sessionStatus"`
 		StatusReason struct {
-			Description string
+      Description string `metric_name:"member.statusReason" source_type:"attribute"`
 		} `json:"status.statusReason"`
 		// inventory
 		MaximumConnections struct {

--- a/src/definition/virtual_server.go
+++ b/src/definition/virtual_server.go
@@ -31,31 +31,34 @@ type LtmVirtualStatsNestedStats struct {
 	Kind    string `json:"kind"`
 	Entries struct {
 		AvailabilityState struct {
-			Description string
-		} `json:"status.availabilityState"`
+			ParsedDescription *int `metric_name:"virtualserver.availabilityState" source_type:"gauge"`
+      Description string
+    } `json:"status.availabilityState"`
 		CurrentConnections struct {
-			Value int
-		} `json:"clientside.curConns"`
+			Value int `metric_name:"virtualserver.connections" source_type:"gauge"`
+    } `json:"clientside.curConns"`
 		DataIn struct {
-			Value int
-		} `json:"clientside.bitsIn"`
+			ParsedValue *int `metric_name:"virtualserver.inDataInBytes" source_type:"rate"`
+      Value int
+    } `json:"clientside.bitsIn"`
 		DataOut struct {
-			Value int
-		} `json:"clientside.bitsOut"`
+			ParsedValue *int `metric_name:"virtualserver.outDataInBytes" source_type:"rate"`
+      Value int
+    } `json:"clientside.bitsOut"`
 		EnabledState struct {
-			Description string
-		} `json:"status.enabledState"`
+			ParsedDescription *int  `metric_name:"virtualserver.enabled" source_type:"gauge"`
+    } `json:"status.enabledState"`
 		PacketsIn struct {
-			Value int
-		} `json:"clientside.pktsIn"`
+      Value int `metric_name:"virtualserver.packetsReceived" source_type:"rate"`
+    } `json:"clientside.pktsIn"`
 		PacketsOut struct {
-			Value int
-		} `json:"clientside.pktsOut"`
+      Value int `metric_name:"virtualserver.packetsSent" source_type:"rate"`
+    } `json:"clientside.pktsOut"`
 		Requests struct {
-			Value int
-		} `json:"totRequests"`
+      Value int `metric_name:"virtualserver.requests" source_type:"rate"`
+    } `json:"totRequests"`
 		StatusReason struct {
-			Description string
-		} `json:"status.statusReason"`
+      Description string `metric_name:"virtualserver.statusReason" source_type:"attribute"`
+    } `json:"status.statusReason"`
 	}
 }


### PR DESCRIPTION
Added metric names. If the metric needs post-processing, created another metric in the same location with `Processed` appended to the name. These are pointers so they will unmarshal correctly