### PR TITLE
Fix poor metric name from 'currentConnections' to 'sessions'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.0.3 - 2019-03-19
+### Fixed
+- Rename metric pool.currentConnections to pool.sessions
+
 ## 1.0.2 - 2019-02-26
 ### Fixed
 - Fix definition file to correct inventory prefix

--- a/spec.csv
+++ b/spec.csv
@@ -68,7 +68,7 @@ f5,pool.connqAllAgeEma,Gauge,true,Sum of pool member queue age exponential movin
 f5,pool.connqAllAgeHead,Gauge,true,Sum of pool member queue age head
 f5,pool.connqAllAgeMax,Gauge,true,Sum of pool member queue age all-time max
 f5,pool.connqAllDepth,Gauge,true,Sum of pool member depth
-f5,pool.currentConnections,Gauge,true,Current connections
+f5,pool.sessions,Gauge,true,Current connections
 f5,pool.minActiveMembers,Gauge,true,Pool minimum active members
 f5,member.availabilityState,Gauge,true,"Current availability from the BIG-IP System 0 = Offline, 1 = Unknown, 2 = Online"
 f5,member.connections,Gauge,true,Current Connections

--- a/src/definition/pool.go
+++ b/src/definition/pool.go
@@ -119,7 +119,7 @@ type LtmPoolStatsEntryValueNestedStats struct {
 			Value int `metric_name:"pool.connqAllDepth" source_type:"gauge"`
 		} `json:"connqAll.depth"`
 		CurSessions struct {
-			Value int `metric_name:"pool.currentConnections" source_type:"gauge"`
+			Value int `metric_name:"pool.sessions" source_type:"gauge"`
 		} `json:"curSessions"`
 		MinActiveMembers struct {
 			Value int `metric_name:"pool.minActiveMembers" source_type:"gauge"`

--- a/src/f5.go
+++ b/src/f5.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	integrationName    = "com.newrelic.f5"
-	integrationVersion = "1.0.2"
+	integrationVersion = "1.0.3"
 )
 
 var (


### PR DESCRIPTION
#### Description of the changes

Removes ambiguity around pool.currentConnections and pool.connections metric names.
pool.currentConnections is renamed to pool.sessions, this fits with the member.sessions and node.sessions metrics.

fixes #14

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
