### PR TITLE
Updating golang to 1.18, adding workaround for commonName deprecation

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GO_VERSION: '1.14'
+  GO_VERSION: '1.18'
   INTEGRATION: "f5"
   ORIGINAL_REPO_NAME: 'newrelic/nri-f5'
   REPO_FULL_NAME: ${{ github.event.repository.full_name }}

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -11,7 +11,7 @@ env:
   TAG: "v0.0.0" # needed for goreleaser windows builds
   REPO_FULL_NAME: ${{ github.event.repository.full_name }}
   ORIGINAL_REPO_NAME: "newrelic/nri-f5"
-  GO_VERSION: '1.14'
+  GO_VERSION: '1.18'
   DOCKER_LOGIN_AVAILABLE: ${{ secrets.OHAI_DOCKER_HUB_ID }}
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.6.0 (2022-08-01)
+### Fixed
+Bumped the goversion used to build the integration. Upgrading the goversion to 1.18,
+
+In particular in the new golang version the CommonName is no longer taken into consideration while validating certificates.
+> The deprecated, legacy behavior of treating the CommonName field on X.509 certificates as a host name when no Subject Alternative Names are present is now disabled by default.
+
+This could be an issue for users still relying on legacy `commonName` and not on `Subject Alternative Name`. In that case they would see an error message like:
+```
+[ERR] Encountered fatal error: Post [...] x509:  certificate relies on legacy Common Name field, use SANs instead
+```
+
+To overcome this issue the user should update the certificate relying on `Subject Alternative Name`. 
+In the meanwhile as a workaround they could also pass the new argument `--ssl_insecure_skip_verify` to skip the certificate validation.
+
 ## 2.5.3 (2022-06-20)
 ### Changed
 - Updated dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This could be an issue for users still relying on legacy `commonName` and not on
 ```
 
 To overcome this issue the user should update the certificate relying on `Subject Alternative Name`. 
-In the meanwhile as a workaround they could also pass the new argument `--tls_insecure_skip_verify` to skip the certificate validation.
+While the certificate is not updated, certificate validation could be disabled setting --tls_insecure_skip_verify` to true.
 
 ## 2.5.3 (2022-06-20)
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This could be an issue for users still relying on legacy `commonName` and not on
 ```
 
 To overcome this issue the user should update the certificate relying on `Subject Alternative Name`. 
-In the meanwhile as a workaround they could also pass the new argument `--ssl_insecure_skip_verify` to skip the certificate validation.
+In the meanwhile as a workaround they could also pass the new argument `--tls_insecure_skip_verify` to skip the certificate validation.
 
 ## 2.5.3 (2022-06-20)
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This could be an issue for users still relying on legacy `commonName` and not on
 ```
 
 To overcome this issue the user should update the certificate relying on `Subject Alternative Name`. 
-While the certificate is not updated, certificate validation could be disabled setting --tls_insecure_skip_verify` to true.
+While the certificate is not updated, certificate validation could be disabled setting `--tls_insecure_skip_verify` to true.
 
 ## 2.5.3 (2022-06-20)
 ### Changed

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ For installation and usage instructions, see our [documentation web site](https:
 
 ## Building
 
-Golang is required to build the integration. We recommend Golang 1.18.
-
 After cloning this repository, go to the directory of the F5 integration and build it:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For installation and usage instructions, see our [documentation web site](https:
 
 ## Building
 
-Golang is required to build the integration. We recommend Golang 1.14.
+Golang is required to build the integration. We recommend Golang 1.18.
 
 After cloning this repository, go to the directory of the F5 integration and build it:
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-buster
+FROM golang:1.18-buster
 
 ARG GH_VERSION='1.9.2'
 

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,15 @@
 module github.com/newrelic/nri-f5
 
-go 1.14
+go 1.18
 
 require (
 	github.com/newrelic/infra-integrations-sdk v3.7.3+incompatible
+	github.com/stretchr/testify v1.8.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/stretchr/testify v1.7.3
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.3 h1:dAm0YRdRQlWojc3CrCRgPBzG5f941d0zvAKu7qY4e+I=
-github.com/stretchr/testify v1.7.3/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/src/arguments/arguments.go
+++ b/src/arguments/arguments.go
@@ -21,7 +21,7 @@ type ArgumentList struct {
 	PartitionFilter       string `default:"[\"Common\"]" help:"JSON array of partitions to collect"`
 	MaxConcurrentRequests int    `default:"10" help:"Maximum number of requests running concurrently"`
 	ShowVersion           bool   `default:"false" help:"Print build information and exit"`
-	SslInsecureSkipVerify bool   `default:"false" help:"Skip verification of the certificate sent by the host."`
+	TLSInsecureSkipVerify bool   `default:"false" help:"Skip verification of the certificate sent by the host."`
 }
 
 // Parse validates and parses out regex patterns from the input arguments

--- a/src/arguments/arguments.go
+++ b/src/arguments/arguments.go
@@ -21,6 +21,7 @@ type ArgumentList struct {
 	PartitionFilter       string `default:"[\"Common\"]" help:"JSON array of partitions to collect"`
 	MaxConcurrentRequests int    `default:"10" help:"Maximum number of requests running concurrently"`
 	ShowVersion           bool   `default:"false" help:"Print build information and exit"`
+	SslInsecureSkipVerify bool   `default:"false" help:"Skip verification of the certificate sent by the host."`
 }
 
 // Parse validates and parses out regex patterns from the input arguments

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -40,7 +40,7 @@ func NewClient(args *arguments.ArgumentList) (*F5Client, error) {
 	if args.CABundleFile != "" {
 		options = append(options, nrHttp.WithCABundleFile(args.CABundleFile))
 	}
-	if args.SslInsecureSkipVerify {
+	if args.TLSInsecureSkipVerify {
 		options = append(options, nrHttp.WithTLSInsecureSkipVerify())
 	}
 

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -40,6 +40,10 @@ func NewClient(args *arguments.ArgumentList) (*F5Client, error) {
 	if args.CABundleFile != "" {
 		options = append(options, nrHttp.WithCABundleFile(args.CABundleFile))
 	}
+	if args.SslInsecureSkipVerify {
+		options = append(options, nrHttp.WithTLSInsecureSkipVerify())
+	}
+
 	options = append(options, nrHttp.WithTimeout(time.Duration(args.Timeout)*time.Second))
 
 	httpClient, err := nrHttp.New(options...)

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,5 +1,5 @@
 module github.com/newrelic/nri-f5/tools
 
-go 1.14
+go 1.18
 
 require github.com/golangci/golangci-lint v1.46.2


### PR DESCRIPTION
Fix https://github.com/newrelic/nri-f5/issues/37

In particular in the new golang version the CommonName is no longer taken into consideration while validating certificates.
> The deprecated, legacy behavior of treating the CommonName field on X.509 certificates as a host name when no Subject Alternative Names are present is now disabled by default.

This could be an issue for users still relying on legacy `commonName` and not on `Subject Alternative Name`. In that case they would see an error message like:
```
[ERR] Encountered fatal error: Post [...] x509:  certificate relies on legacy Common Name field, use SANs instead
```

To overcome this issue the user should update the certificate relying on `Subject Alternative Name`. 
In the meanwhile as a workaround they could also pass the new argument `--ssl_insecure_skip_verify` to skip the certificate validation.
